### PR TITLE
Revising ignore functionality

### DIFF
--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -282,7 +282,7 @@ end
       physdesc.children.each do |child|
         if child.respond_to?(:name) && child.name == 'extent'
           child_content = child.content.strip
-          if extent_number_and_type.nil? && child_content =~ /^([0-9\.,]+)+\s+(.*)$/
+          if extent_number_and_type.nil? && child_content =~ /^([0-9\.]+)+\s+(.*)$/
             extent_number_and_type = {:number => $1, :extent_type => $2}
           else
             other_extent_data << child_content

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -33,7 +33,12 @@ class BHLEADConverter < EADConverter
 
   def self.configure
     super
-    
+
+# Test this on nested lists:
+# with 'item/list' do
+#    @ignore = true
+
+
 # We'll be importing most of our subjects and agents separately and linking directly to the URI from our finding
 # aids and accession records.
 # This will check our subject, geogname, genreform, corpname, famname, and persname elements in our EADs for a ref attribute
@@ -66,7 +71,7 @@ class BHLEADConverter < EADConverter
            end
         end
      end
-    
+
     with 'origination/corpname' do
         if att('ref')
             set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'creator'}
@@ -74,9 +79,9 @@ class BHLEADConverter < EADConverter
             make_corp_template(:role => 'creator')
         end
     end
-    
+
     with 'controlaccess/corpname' do
-    
+
         corpname = Nokogiri::XML::DocumentFragment.parse(inner_xml)
         terms ||= []
         corpname.children.each do |child|
@@ -111,7 +116,7 @@ class BHLEADConverter < EADConverter
                 terms << {'term' => term, 'term_type' => term_type, 'vocabulary' => '/vocabularies/1'}
             end
         end
-        
+
         if att('ref')
             set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms}
         else
@@ -126,7 +131,7 @@ class BHLEADConverter < EADConverter
             make_person_template(:role => 'creator')
         end
     end
-    
+
     with 'controlaccess/persname' do
         persname = Nokogiri::XML::DocumentFragment.parse(inner_xml)
         terms ||= []
@@ -137,7 +142,7 @@ class BHLEADConverter < EADConverter
                 terms << {'term' => term, 'term_type' => term_type, 'vocabulary' => '/vocabularies/1'}
             end
         end
-        
+
         if att('ref')
             set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms}
         else
@@ -277,7 +282,7 @@ end
       physdesc.children.each do |child|
         if child.respond_to?(:name) && child.name == 'extent'
           child_content = child.content.strip
-          if extent_number_and_type.nil? && child_content =~ /^([0-9\.]+)+\s+(.*)$/
+          if extent_number_and_type.nil? && child_content =~ /^([0-9\.,]+)+\s+(.*)$/
             extent_number_and_type = {:number => $1, :extent_type => $2}
           else
             other_extent_data << child_content

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -26,7 +26,7 @@ class BHLEADConverter < EADConverter
   	return content if content.nil?
     content.delete!("\n") # first we remove all linebreaks, since they're probably unintentional
     content.gsub("<p>","").gsub("</p>","\n\n" ).gsub("<p/>","\n\n")
-  		   .gsub("<lb/>", "\n\n").gsub("<lb>","\n\n").gsub("</lb>","").gsub(/\,+\s?+$/,"") # also remove trailing commas
+  		   .gsub("<lb/>", "\n\n").gsub("<lb>","\n\n").gsub("</lb>","").gsub(/[\s,]+$/,"") # also remove trailing commas
   	     .strip
   end
 
@@ -34,10 +34,75 @@ class BHLEADConverter < EADConverter
   def self.configure
     super
 
-# Test this on nested lists:
-# with 'item/list' do
-#    @ignore = true
+# BEGIN CONDITIONAL SKIPS
 
+# We have lists and indexes with all sorts of crazy things, like <container>, <physdesc>, <physloc>, etc. tags within <item>  or <ref> tags
+# So, we need to tell the importer to skip those things only when they appear in places where they shouldn't, otherwise do
+# it's normal thing
+
+%w(abstract langmaterial materialspec physfacet physloc).each do |note|
+      with note do |node|
+        next if context == :note_orderedlist # skip these
+        next if context == :items # these too
+        content = inner_xml
+        next if content =~ /\A<language langcode=\"[a-z]+\"\/>\Z/
+
+
+        if content.match(/\A<language langcode=\"[a-z]+\"\s*>([^<]+)<\/language>\Z/)
+          content = $1
+        end
+
+        make :note_singlepart, {
+          :type => note,
+          :persistent_id => att('id'),
+          :content => format_content( content.sub(/<head>.*?<\/head>/, '') )
+        } do |note|
+          set ancestor(:resource, :archival_object), :notes, note
+        end
+      end
+    end
+
+with 'list' do
+      next if ancestor(:note_index) # skip these
+      if  ancestor(:note_multipart)
+        left_overs = insert_into_subnotes
+	  else
+        left_overs = nil
+        make :note_multipart, {
+          :type => 'odd',
+          :persistent_id => att('id'),
+        } do |note|
+          set ancestor(:resource, :archival_object), :notes, note
+        end
+      end
+
+
+      # now let's make the subnote list
+      type = att('type')
+      if type == 'deflist' || (type.nil? && inner_xml.match(/<deflist>/))
+        make :note_definedlist do |note|
+          set ancestor(:note_multipart), :subnotes, note
+        end
+      else
+        make :note_orderedlist, {
+          :enumeration => att('numeration')
+        } do |note|
+          set ancestor(:note_multipart), :subnotes, note
+        end
+      end
+
+
+      # and finally put the leftovers back in the list of subnotes...
+      if ( !left_overs.nil? && left_overs["content"] && left_overs["content"].length > 0 )
+        set ancestor(:note_multipart), :subnotes, left_overs
+      end
+
+    end
+
+# END CONDITIONAL SKIPS
+
+
+# BEGIN CUSTOM SUBJECT AND AGENT IMPORTS
 
 # We'll be importing most of our subjects and agents separately and linking directly to the URI from our finding
 # aids and accession records.
@@ -81,7 +146,6 @@ class BHLEADConverter < EADConverter
     end
 
     with 'controlaccess/corpname' do
-
         corpname = Nokogiri::XML::DocumentFragment.parse(inner_xml)
         terms ||= []
         corpname.children.each do |child|
@@ -150,7 +214,267 @@ class BHLEADConverter < EADConverter
         end
     end
 
+# END CUSTOM SUBJECT AND AGENT IMPORTS
 
+
+# BEGIN PHYSDESC CUSTOMIZATIONS
+
+# The stock EAD importer doesn't import <physfacet> and <dimensions> tags into extent objects; instead making them notes
+# This is a corrected version
+ with 'physdesc' do
+      next if context == :note_orderedlist # skip these
+      physdesc = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+      extent_number_and_type = nil
+      dimensions = nil
+      physfacet = nil
+      other_extent_data = []
+      make_note_too = false
+
+      # We want the EAD importer to know when we're importing partial extents, which following ASpace practice is indicated by "altrender" attribute
+      portion = att('altrender') || 'whole'
+
+      physdesc.children.each do |child|
+        if child.name == 'extent'
+          child_content = child.content.strip
+          if extent_number_and_type.nil? && child_content =~ /^([0-9\.]+)+\s+(.*)$/
+            extent_number_and_type = {:number => $1, :extent_type => $2}
+          else
+            other_extent_data << child_content
+          end
+
+        elsif child.name == 'physfacet'
+          child_content = child.content.strip
+          physfacet = child_content
+
+        elsif child.name == 'dimensions'
+          child_content = child.content.strip
+          dimensions = child_content
+
+        else
+          # there's other info here; make a note as well
+          make_note_too = true unless child.text.strip.empty?
+        end
+      end
+
+      # only make an extent if we got a number and type, otherwise put all physdesc contents into a note
+      if extent_number_and_type
+        make :extent, {
+          :number => $1,
+          :extent_type => $2,
+          :portion => portion,
+          :container_summary => other_extent_data.join('; '),
+          :physical_details => physfacet,
+          :dimensions => dimensions
+        } do |extent|
+          set ancestor(:resource, :archival_object), :extents, extent
+        end
+      else
+        make_note_too = true;
+      end
+
+      if make_note_too
+        content =  physdesc.to_xml(:encoding => 'utf-8')
+        make :note_singlepart, {
+          :type => 'physdesc',
+          :persistent_id => att('id'),
+          :content => format_content( content.sub(/<head>.*?<\/head>/, '').strip )
+        } do |note|
+          set ancestor(:resource, :archival_object), :notes, note
+        end
+      end
+    end
+
+    # overwriting the default dimensions and physfacet functionality
+    with "dimensions" do
+      next
+    end
+
+    with "physfacet" do
+      next
+    end
+
+# END PHYSDESC CUSTOMIZATIONS
+
+
+# BEGIN INDEX CUSTOMIZATIONS
+
+# The stock EAD converter creates separate index items for each indexentry,
+# one for the value (persname, famname, etc) and one for the reference (ref),
+# even when they are within the same indexentry and are related
+# (i.e., the persname is a correspondent, the ref is a date or a location at which
+# correspondence with that person can be found).
+# The Bentley's <indexentry>s generally look something like:
+# # <indexentry><persname>Some person</persname><ref>Some date or folder</ref></indexentry>
+# # As the <persname> and the <ref> are associated with one another,
+# we want to keep them together in the same index item in ArchiveSpace.
+
+# This will treat each <indexentry> as one item,
+# creating an index item with a 'value' from the <persname>, <famname>, etc.
+# and a 'reference_text' from the <ref>.
+
+with 'indexentry' do
+
+  entry_type = ''
+  entry_value = ''
+  entry_reference = ''
+
+  indexentry = Nokogiri::XML::DocumentFragment.parse(inner_xml)
+
+  indexentry.children.each do |child|
+
+    case child.name
+      when 'name'
+      entry_value << child.content
+      entry_type << 'name'
+      when 'persname'
+      entry_value << child.content
+      entry_type << 'person'
+      when 'famname'
+      entry_value << child.content
+      entry_type << 'family'
+      when 'corpname'
+      entry_value << child.content
+      entry_type << 'corporate_entity'
+      when 'subject'
+      entry_value << child.content
+      entry_type << 'subject'
+      when 'function'
+      entry_value << child.content
+      entry_type << 'function'
+      when 'occupation'
+      entry_value << child.content
+      entry_type << 'occupation'
+      when 'genreform'
+      entry_value << child.content
+      entry_type << 'genre_form'
+      when 'title'
+      entry_value << child.content
+      entry_type << 'title'
+      when 'geogname'
+      entry_value << child.content
+      entry_type << 'geographic_name'
+    end
+
+    if child.name == 'ref'
+    entry_reference << child.content
+    end
+
+  end
+
+	make :note_index_item, {
+	  :type => entry_type,
+	  :value => entry_value,
+	  :reference_text => entry_reference
+	  } do |item|
+	set ancestor(:note_index), :items, item
+	end
+end
+
+# Skip the stock importer actions to avoid confusion/duplication
+{
+      'name' => 'name',
+      'persname' => 'person',
+      'famname' => 'family',
+      'corpname' => 'corporate_entity',
+      'subject' => 'subject',
+      'function' => 'function',
+      'occupation' => 'occupation',
+      'genreform' => 'genre_form',
+      'title' => 'title',
+      'geogname' => 'geographic_name'
+    }.each do |k, v|
+      with "indexentry/#{k}" do |node|
+        next
+      end
+    end
+
+    with 'indexentry/ref' do
+       next
+    end
+
+# END INDEX CUSTOMIZATIONS
+
+# BEGIN DAO TITLE CUSTOMIZATIONS
+
+# The Bentley has many EADs with <dao> tags that lack title attributes.
+# The stock ArchivesSpace EAD Converter uses each <dao>'s title attribute as
+# the value for the imported digital object's title, which is a required property.
+# As a result, all of our EADs with <dao> tags fail when trying to import into ArchivesSpace.
+# This section of the BHL EAD Converter plugin modifies the stock ArchivesSpace EAD Converter
+# by forming a string containing the digital object's parent archival object's title and date (if both exist),
+# or just its title (if only the title exists), or just it's date (if only the date exists)
+# and then using that string as the imported digital object's title.
+
+with 'dao' do
+
+# This forms a title string using the parent archival object's title, if it exists
+  daotitle = ''
+  ancestor(:archival_object ) do |ao|
+    if ao.title
+      daotitle << ao.title
+    else
+      daotitle = nil
+    end
+  end
+
+# This forms a date string using the parent archival object's date expression,
+# or its begin date - end date, or just it's begin date, if any exist
+  daodate = ''
+  ancestor(:archival_object) do |aod|
+    if aod.dates && aod.dates.length > 0
+      aod.dates.each do |dl|
+        if dl['expression'].length > 0
+          daodate += ', ' if daodate.length > 0
+          daodate += dl['expression']
+        else
+          daodate = nil
+        end
+      end
+    end
+  end
+
+  title = daotitle
+  date_label = daodate if daodate.length > 0
+
+# This forms a display string using the parent archival object's title and date (if both exist),
+# or just its title or date (if only one exists)
+  display_string = title || ''
+  display_string += ', ' if title && date_label
+  display_string += date_label if date_label
+
+  make :instance, {
+    :instance_type => 'digital_object'
+    } do |instance|
+  set ancestor(:resource, :archival_object), :instances, instance
+  end
+
+# We'll use either the <dao> title attribute (if it exists) or our display_string (if the title attribute does not exist)
+  make :digital_object, {
+    :digital_object_id => SecureRandom.uuid,
+    :title => att('title') || display_string,
+    } do |obj|
+      obj.file_versions <<  {
+      :use_statement => att('role'),
+      :file_uri => att('href'),
+      :xlink_actuate_attribute => att('actuate'),
+      :xlink_show_attribute => att('show')
+      }
+    set ancestor(:instance), :digital_object, obj
+    end
+  end
+end
+
+# END DAO TITLE CUSTOMIZATIONS
+
+
+
+
+
+=begin
+# Note: The following bits are here for historical reasons
+# We have either decided against implementing the functionality OR the ArchivesSpace importer has changed, deprecating the following customizations
+
+#BEGIN IGNORE
 # Setting some of these to ignore because we have some physdesc, container, etc.
 # Within list/items in our descgrps at the end of finding aids.
 # Without setting these to ignore, ASpace both makes the list AND makes separate
@@ -159,7 +483,6 @@ class BHLEADConverter < EADConverter
 # Note: if using this in conjunction with the Yale container management plugin,
 # be sure to include the line 'next ignore if @ignore' within the with container do
 # section of the ConverterExtraContainerValues module.
-
 with 'archref/container' do
     @ignore = true
 end
@@ -268,62 +591,9 @@ end
   end
 end
 
-
-
-# The stock EAD importer imports all extents as portion = "whole"
-# We have some partial extents that we want the importer to import as portion = "part"
- with 'physdesc' do
-     next ignore if @ignore
-      portion = att('altrender') || 'whole' # We want the EAD importer to know when we're importing partial extents, which we indicator via the altrender attribute
-      physdesc = Nokogiri::XML::DocumentFragment.parse(inner_xml)
-      extent_number_and_type = nil
-      other_extent_data = []
-      make_note_too = false
-      physdesc.children.each do |child|
-        if child.respond_to?(:name) && child.name == 'extent'
-          child_content = child.content.strip
-          if extent_number_and_type.nil? && child_content =~ /^([0-9\.]+)+\s+(.*)$/
-            extent_number_and_type = {:number => $1, :extent_type => $2}
-          else
-            other_extent_data << child_content
-          end
-        else
-          # there's other info here; make a note as well
-          make_note_too = true unless child.text.strip.empty?
-        end
-      end
-
-      # only make an extent if we got a number and type
-      if extent_number_and_type
-        make :extent, {
-          :number => $1,
-          :extent_type => $2,
-          :portion => portion,
-          :container_summary => other_extent_data.join('; ')
-        } do |extent|
-          set ancestor(:resource, :archival_object), :extents, extent
-        end
-      else
-        make_note_too = true;
-      end
-
-      if make_note_too
-        content =  physdesc.to_xml(:encoding => 'utf-8')
-        make :note_singlepart, {
-          :type => 'physdesc',
-          :persistent_id => att('id'),
-          :content => format_content( content.sub(/<head>.*?<\/head>/, '').strip )
-        } do |note|
-          set ancestor(:resource, :archival_object), :notes, note
-        end
-      end
-
-    end
-
-=begin
+#BEGIN RIGHTS STATEMENTS
 # The stock ASpace EAD importer only makes "Conditions Governing Access" notes out of <accessrestrict> tags
 # We want to also import our <accessrestrict> tags that have a restriction end date as a "Rights Statements"
-# Update: we probably aren't actually going to do this. Leaving this here, commented out, for future reference.
 
 # Let ArchivesSpace do its normal thing with accessrestrict
     %w(accessrestrict accessrestrict/legalstatus \
@@ -372,259 +642,5 @@ with 'accessrestrict/date' do
     end
 end
 =end
-
-with 'list/head' do |node|
-  next ignore if @ignore
-  set :title, format_content( inner_xml ) if context == :note_orderedlist
-end
-
-with 'descgrp/list' do
-
-    if  ancestor(:note_multipart)
-      left_overs = insert_into_subnotes
-    elsif ancestor(:note_index) # Set this to ignore because our <ref>s have <list>s
-      @ignore = true
-    else
-      left_overs = nil
-      make :note_multipart, {
-        :type => 'odd',
-        :persistent_id => att('id'),
-      } do |note|
-        set ancestor(:resource, :archival_object), :notes, note
-      end
-    end
-
-
-    # now let's make the subnote list
-    type = att('type')
-    if type == 'deflist' || (type.nil? && inner_xml.match(/<deflist>/))
-      make :note_definedlist do |note|
-        set ancestor(:note_multipart), :subnotes, note
-      end
-    else
-      make :note_orderedlist, {
-        :enumeration => att('numeration')
-      } do |note|
-        set ancestor(:note_multipart), :subnotes, note
-      end
-    end
-
-
-    # and finally put the leftovers back in the list of subnotes...
-    if ( !left_overs.nil? && left_overs["content"] && left_overs["content"].length > 0 )
-      set ancestor(:note_multipart), :subnotes, left_overs
-    end
-
-  end
-
-
-
- with 'list' do
-      next ignore if @ignore
-
-      if  ancestor(:note_multipart)
-        left_overs = insert_into_subnotes
-      elsif ancestor(:note_index) #Set this to ignore because our <ref>s have <list>s
-	    @ignore = true
-	  else
-        left_overs = nil
-        make :note_multipart, {
-          :type => 'odd',
-          :persistent_id => att('id'),
-        } do |note|
-          set ancestor(:resource, :archival_object), :notes, note
-        end
-      end
-
-
-      # now let's make the subnote list
-      type = att('type')
-      if type == 'deflist' || (type.nil? && inner_xml.match(/<deflist>/))
-        make :note_definedlist do |note|
-          set ancestor(:note_multipart), :subnotes, note
-        end
-      else
-        make :note_orderedlist, {
-          :enumeration => att('numeration')
-        } do |note|
-          set ancestor(:note_multipart), :subnotes, note
-        end
-      end
-
-
-      # and finally put the leftovers back in the list of subnotes...
-      if ( !left_overs.nil? && left_overs["content"] && left_overs["content"].length > 0 )
-        set ancestor(:note_multipart), :subnotes, left_overs
-      end
-
-    end
-
-# The stock EAD converter creates separate index items for each indexentry,
-# one for the value (persname, famname, etc) and one for the reference (ref),
-# even when they are within the same indexentry and are related
-# (i.e., the persname is a correspondent, the ref is a date or a location at which
-# correspondence with that person can be found).
-# The Bentley's <indexentry>s generally look something like:
-# # <indexentry><persname>Some person</persname><ref>Some date or folder</ref></indexentry>
-# # As the <persname> and the <ref> are associated with one another,
-# we want to keep them together in the same index item in ArchiveSpace.
-
-# First we set the stock indexentry actions to ignore to avoid running each indexentry/x and indexentry/ref multiple times.
-	{
-      'name' => 'name',
-      'persname' => 'person',
-      'famname' => 'family',
-      'corpname' => 'corporate_entity',
-      'subject' => 'subject',
-      'function' => 'function',
-      'occupation' => 'occupation',
-      'genreform' => 'genre_form',
-      'title' => 'title',
-      'geogname' => 'geographic_name'
-    }.each do |k, v|
-      with "indexentry/#{k}" do |node|
-        @ignore = true
-		end
-    end
-
-    with 'indexentry/ref' do
-        @ignore = true
-    end
-
-
-# This will treat each <indexentry> as one item,
-# creating an index item with a 'value' from the <persname>, <famname>, etc.
-# and a 'reference_text' from the <ref>.
-
-with 'indexentry' do
-
-  entry_type = ''
-  entry_value = ''
-  entry_reference = ''
-
-  indexentry = Nokogiri::XML::DocumentFragment.parse(inner_xml)
-
-  indexentry.children.each do |child|
-
-    case child.name
-      when 'name'
-      entry_value << child.content
-      entry_type << 'name'
-      when 'persname'
-      entry_value << child.content
-      entry_type << 'person'
-      when 'famname'
-      entry_value << child.content
-      entry_type << 'family'
-      when 'corpname'
-      entry_value << child.content
-      entry_type << 'corporate_entity'
-      when 'subject'
-      entry_value << child.content
-      entry_type << 'subject'
-      when 'function'
-      entry_value << child.content
-      entry_type << 'function'
-      when 'occupation'
-      entry_value << child.content
-      entry_type << 'occupation'
-      when 'genreform'
-      entry_value << child.content
-      entry_type << 'genre_form'
-      when 'title'
-      entry_value << child.content
-      entry_type << 'title'
-      when 'geogname'
-      entry_value << child.content
-      entry_type << 'geographic_name'
-    end
-
-    if child.name == 'ref'
-    entry_reference << child.content
-    end
-
-  end
-
-	make :note_index_item, {
-	  :type => entry_type,
-	  :value => entry_value,
-	  :reference_text => entry_reference
-	  } do |item|
-	set ancestor(:note_index), :items, item
-	end
-end
-
-
-
-# The Bentley has many EADs with <dao> tags that lack title attributes.
-# The stock ArchivesSpace EAD Converter uses each <dao>'s title attribute as
-# the value for the imported digital object's title, which is a required property.
-# As a result, all of our EADs with <dao> tags fail when trying to import into ArchivesSpace.
-# This section of the BHL EAD Converter plugin modifies the stock ArchivesSpace EAD Converter
-# by forming a string containing the digital object's parent archival object's title and date (if both exist),
-# or just its title (if only the title exists), or just it's date (if only the date exists)
-# and then using that string as the imported digital object's title.
-
-with 'dao' do
-
-# This forms a title string using the parent archival object's title, if it exists
-  daotitle = ''
-  ancestor(:archival_object ) do |ao|
-    if ao.title
-      daotitle << ao.title
-    else
-      daotitle = nil
-    end
-  end
-
-# This forms a date string using the parent archival object's date expression,
-# or its begin date - end date, or just it's begin date, if any exist
-  daodate = ''
-  ancestor(:archival_object) do |aod|
-    if aod.dates && aod.dates.length > 0
-      aod.dates.each do |dl|
-        if dl['expression'].length > 0
-          daodate += dl['expression']
-        elsif (dl['begin'].length > 0 and dl['end'].length > 0) and (dl['begin'] != dl['end']) and not (dl['expression'].length > 0)
-          daodate += "#{dl['begin']} - #{dl['end']}"
-        elsif dl['begin'].length > 0 and (dl['begin'] = dl['end']) and not (dl['expression'].length > 0)
-          daodate += "#{dl['begin']}"
-        else
-          daodate = nil
-        end
-      end
-    end
-  end
-
-  title = daotitle
-  date_label = daodate if daodate.length > 0
-
-# This forms a display string using the parent archival object's title and date (if both exist),
-# or just its title or date (if only one exists)
-  display_string = title || ''
-  display_string += ', ' if title && date_label
-  display_string += date_label if date_label
-
-  make :instance, {
-    :instance_type => 'digital_object'
-    } do |instance|
-  set ancestor(:resource, :archival_object), :instances, instance
-  end
-
-# We'll use either the <dao> title attribute (if it exists) or our display_string (if the title attribute does not exist)
-  make :digital_object, {
-    :digital_object_id => SecureRandom.uuid,
-    :title => att('title') || display_string,
-    } do |obj|
-      obj.file_versions <<  {
-      :use_statement => att('role'),
-      :file_uri => att('href'),
-      :xlink_actuate_attribute => att('actuate'),
-      :xlink_show_attribute => att('show')
-      }
-    set ancestor(:instance), :digital_object, obj
-    end
-  end
-end
 
 end


### PR DESCRIPTION
The newest version of ArchivesSpace modified the "ignore" functionality (see https://github.com/archivesspace/archivesspace/commit/fb860a81f70a98eb489564b6e17d2c120c40fc5f)

This sort of messed up some of the functionality of the bhl-ead-importer that ignored certain things in lists, indexes, etc. etc. I (think?) I fixed it.

Also cc @walkerdb: This pull request also includes your modifications to physdesc, because I had to change some things about how dimensions and physfacets are skipped in indexes and lists anyway, and it turns out that your modifications handle all of that. I still think we should modify this slightly to make dimension notes for dimensions and physical facet notes for physfacets, though.
