### PR TITLE
Nested list and agent relator modifications

### DIFF
--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -143,6 +143,7 @@ with 'list' do
 
     
     with 'list/item' do
+        #next if context == :items
         # Okay this is another one of those hacky things that work
         # The problem: we have many items nested within items, like <list><item>First item <list><item>Subitem</item></list></item></list>
         # This would make one item like:
@@ -214,13 +215,14 @@ with 'list' do
                 terms << {'term' => term, 'term_type' => term_type, 'vocabulary' => '/vocabularies/1'}
             end
         end
+        
+        relator = nil
         if att('encodinganalog') == '710'
             relator = 'ctb'
-        else
-            relator = nil
         end
+        
         if att('ref')
-            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator if relator}
+            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator}
         else
             make_corp_template(:role => 'subject')
         end
@@ -245,13 +247,13 @@ with 'list' do
             end
         end
         
+        relator = nil
         if att('encodinganalog') == '700'
             relator = 'ctb'
-        else
-            relator = nil
         end
+        
         if att('ref')
-            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator if relatorl}
+            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator}
         else
             make_family_template(:role => 'subject')
         end
@@ -275,13 +277,14 @@ with 'list' do
                 terms << {'term' => term, 'term_type' => term_type, 'vocabulary' => '/vocabularies/1'}
             end
         end
+        
+        relator = nil
         if att('encodinganalog') == '700'
             relator = 'ctb'
-        else
-            relator = nil
         end
+        
         if att('ref')
-            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator if relator}
+            set ancestor(:resource, :archival_object), :linked_agents, {'ref' => att('ref'), 'role' => 'subject', 'terms' => terms, 'relator' => relator}
         else
             make_person_template(:role => 'subject')
         end

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -152,10 +152,10 @@ with 'list' do
         #   Subitem
         # ArchivesSpace lists are flat and do not allow for nesting lists within lists within items within lists within.. (you get the idea)...
         # Now, it would be nice to have a better way to tell the importer to only account for subitems one time, but there doesn't seem to be
-        # With this modification we can add an attribute of 'skip="true"' to nested items before migration
+        # With this modification we can add an attribute of 'altrender="skip"' to nested items before migration
         # This will ignore those items, and sub out those invalid attributes when importing the inner xml of the top item
-        next if att('skip')
-        set :items, inner_xml.gsub(/\sskip="true"/,'') if context == :note_orderedlist
+        next if att('altrender') == 'skip'
+        set :items, inner_xml.gsub(/\saltrender="skip"/,'') if context == :note_orderedlist
     end
 
 # END CONDITIONAL SKIPS

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -597,6 +597,48 @@ end
 
 # END DAO TITLE CUSTOMIZATIONS
 
+# BEGIN DESCGRP/ODD CUSTOMIZATIONS
+
+with 'descgrp/odd' do |node|
+    content = inner_xml
+    make :note_multipart, {
+        :type => 'odd',
+        :persistent_id => att('id'),
+        :subnotes => {
+            'jsonmodel_type' => 'note_text',
+            'content' => format_content( content )
+        }
+    } do |note|
+    set ancestor(:resource), :notes, note
+end
+end
+
+%w(accessrestrict accessrestrict/legalstatus \
+     accruals acqinfo altformavail appraisal arrangement \
+     bioghist custodhist dimensions \
+     fileplan odd otherfindaid originalsloc phystech \
+     prefercite processinfo relatedmaterial scopecontent \
+     separatedmaterial userestrict ).each do |note|
+    with note do |node|
+      next if node.name == 'odd' && ancestor(:resource)
+      content = inner_xml.tap {|xml|
+        xml.sub!(/<head>.*?<\/head>/m, '')
+        # xml.sub!(/<list [^>]*>.*?<\/list>/m, '')
+        # xml.sub!(/<chronlist [^>]*>.*<\/chronlist>/m, '')
+      }
+
+      make :note_multipart, {
+        :type => node.name,
+        :persistent_id => att('id'),
+        :subnotes => {
+          'jsonmodel_type' => 'note_text',
+          'content' => format_content( content )
+        }
+      } do |note|
+        set ancestor(:resource, :archival_object), :notes, note
+      end
+    end
+  end
 
 
 

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -179,7 +179,7 @@ with 'list' do
       'geogname' => 'geographic',
       'occupation' => 'occupation',
       'subject' => 'topical',
-      'title' => 'uniform_title', # added title since we have some <title> tags in our controlaccesses
+      'title' => 'uniform_title' # added title since we have some <title> tags in our controlaccesses
       }.each do |tag, type|
         with "controlaccess/#{tag}" do
           if att('ref')

--- a/backend/model/bhl_ead_converter.rb
+++ b/backend/model/bhl_ead_converter.rb
@@ -143,7 +143,6 @@ with 'list' do
 
     
     with 'list/item' do
-        #next if context == :items
         # Okay this is another one of those hacky things that work
         # The problem: we have many items nested within items, like <list><item>First item <list><item>Subitem</item></list></item></list>
         # This would make one item like:


### PR DESCRIPTION
This PR includes two modifications:
1. A really hacky way to get ArchivesSpace to not import items within items within lists two or more times. This is something we'll probably need to think about a little more, but since ArchivesSpace lists are flat, the best thing I could come up with is to just import each "top level item" from a list and include all of the sub-list and sub-item mark up in that list item so that it will be preserved on export. This is really unusable in the ArchivesSpace staff/public interface, but there isn't really a better way since we have many nested lists and ArchivesSpace doesn't like that
2. A small addition to check the encodinganalog on persnames, famnames, and corpnames and set the 'relator' value to 'ctb' (for contributor) when appropriate. This will allow us to preserve in spirit if not yet in practice yet another <controlaccess> block that was previously identified only by the <head> tag
